### PR TITLE
Add mobile frame and Tailwind styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # SansMobile003
+
+This repository contains a Vue 3 + Vite + Capacitor mobile application for Sans Reserve.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The UI is built with Tailwind CSS and always renders inside a fixed mobile frame for consistent layout across devices.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sans Reserve App</title>
+  </head>
+  <body class="h-full">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sansmobile",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.3.4",
+    "vue-router": "^4.1.6",
+    "pinia": "^2.1.3",
+    "@capacitor/core": "^5.0.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "vite": "^4.5.0",
+    "@vitejs/plugin-vue": "^4.4.0",
+    "tailwindcss": "^3.4.4",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="mobile-frame">
+    <router-view />
+  </div>
+</template>

--- a/src/api/ApiService.ts
+++ b/src/api/ApiService.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { API_BASE_URL } from '../config/api';
+
+class ApiService {
+  private client = axios.create({ baseURL: API_BASE_URL });
+
+  public async sendPhoneNumber(phone: string) {
+    return this.client.post('/auth/login', { phone });
+  }
+
+  public async verifyCode(phone: string, code: string) {
+    return this.client.post('/auth/verify', { phone, code });
+  }
+
+  public async completeProfile(token: string, firstName: string, lastName: string) {
+    return this.client.post(
+      '/auth/register',
+      { firstName, lastName },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+  }
+
+  public async getProfile(token: string) {
+    return this.client.get('/user/profile', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+}
+
+export default new ApiService();

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body {
+  @apply h-full m-0 bg-gray-100;
+}
+
+#app {
+  @apply flex items-center justify-center h-full;
+}
+
+.mobile-frame {
+  width: 375px;
+  height: 812px;
+  @apply bg-white overflow-hidden mx-auto shadow-lg flex flex-col;
+}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'https://api.sans-reserve.com';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,10 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+import { createPinia } from 'pinia';
+import './assets/main.css';
+
+createApp(App)
+  .use(createPinia())
+  .use(router)
+  .mount('#app');

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,35 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import Login from '../views/Login.vue';
+import EnterCode from '../views/EnterCode.vue';
+import Register from '../views/Register.vue';
+import Home from '../views/Home.vue';
+import { useSessionStore } from '../stores/session';
+
+const routes = [
+  { path: '/', redirect: '/login' },
+  { path: '/login', component: Login },
+  { path: '/enter-code', component: EnterCode },
+  { path: '/register', component: Register },
+  { path: '/home', component: Home },
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+router.beforeEach((to, _from, next) => {
+  const session = useSessionStore();
+  if (['/login', '/enter-code', '/register'].includes(to.path)) {
+    next();
+  } else {
+    if (!session.token || session.isExpired()) {
+      session.clear();
+      next('/login');
+    } else {
+      next();
+    }
+  }
+});
+
+export default router;

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia';
+
+interface UserProfile {
+  id: number;
+  firstName: string;
+  lastName: string;
+  phone: string;
+}
+
+interface SessionState {
+  token: string | null;
+  expiry: number | null;
+  user: UserProfile | null;
+}
+
+const SESSION_KEY = 'sr_session';
+const EXPIRY_KEY = 'sr_expiry';
+
+export const useSessionStore = defineStore('session', {
+  state: (): SessionState => ({
+    token: localStorage.getItem(SESSION_KEY),
+    expiry: localStorage.getItem(EXPIRY_KEY)
+      ? parseInt(localStorage.getItem(EXPIRY_KEY) as string)
+      : null,
+    user: null,
+  }),
+  actions: {
+    saveToken(token: string, days = 7) {
+      this.token = token;
+      const expiry = Date.now() + days * 24 * 60 * 60 * 1000;
+      this.expiry = expiry;
+      localStorage.setItem(SESSION_KEY, token);
+      localStorage.setItem(EXPIRY_KEY, expiry.toString());
+    },
+    clear() {
+      this.token = null;
+      this.expiry = null;
+      this.user = null;
+      localStorage.removeItem(SESSION_KEY);
+      localStorage.removeItem(EXPIRY_KEY);
+    },
+    isExpired(): boolean {
+      if (!this.expiry) return true;
+      return Date.now() > this.expiry;
+    },
+  },
+});

--- a/src/views/EnterCode.vue
+++ b/src/views/EnterCode.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="p-4 flex flex-col h-full">
+    <h1 class="text-xl font-semibold text-center mb-4">Enter Code</h1>
+    <form class="flex flex-col gap-4" @submit.prevent="submit">
+      <input
+        v-model="code"
+        placeholder="SMS Code"
+        class="border rounded-md p-3 text-lg"
+      />
+      <button class="bg-blue-600 text-white py-3 rounded-md" type="submit">
+        Verify
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import api from '../api/ApiService';
+import { useSessionStore } from '../stores/session';
+
+const route = useRoute();
+const router = useRouter();
+const session = useSessionStore();
+
+const code = ref('');
+const phone = route.query.phone as string;
+
+const fetchProfile = async () => {
+  const { data } = await api.getProfile(session.token as string);
+  session.user = data;
+};
+
+const submit = async () => {
+  const { data } = await api.verifyCode(phone, code.value);
+  session.saveToken(data.token);
+  if (data.isNew) {
+    router.push('/register');
+  } else {
+    await fetchProfile();
+    router.push('/home');
+  }
+};
+</script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="p-4 flex flex-col h-full">
+    <h1 class="text-xl font-semibold text-center mb-4">
+      Welcome {{ session.user?.firstName }}
+    </h1>
+    <button class="bg-red-600 text-white py-3 rounded-md" @click="logout">
+      Logout
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useSessionStore } from '../stores/session';
+import { useRouter } from 'vue-router';
+
+const session = useSessionStore();
+const router = useRouter();
+
+const logout = () => {
+  session.clear();
+  router.push('/login');
+};
+</script>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="p-4 flex flex-col h-full">
+    <h1 class="text-xl font-semibold text-center mb-4">Login</h1>
+    <form class="flex flex-col gap-4" @submit.prevent="submit">
+      <input
+        v-model="phone"
+        type="tel"
+        placeholder="Mobile number"
+        class="border rounded-md p-3 text-lg"
+      />
+      <button class="bg-blue-600 text-white py-3 rounded-md" type="submit">
+        Send Code
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import api from '../api/ApiService';
+import { useRouter } from 'vue-router';
+
+const phone = ref('');
+const router = useRouter();
+
+const submit = async () => {
+  await api.sendPhoneNumber(phone.value);
+  router.push({ path: '/enter-code', query: { phone: phone.value } });
+};
+</script>

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="p-4 flex flex-col h-full">
+    <h1 class="text-xl font-semibold text-center mb-4">Complete Profile</h1>
+    <form class="flex flex-col gap-4" @submit.prevent="submit">
+      <input
+        v-model="firstName"
+        placeholder="First name"
+        class="border rounded-md p-3 text-lg"
+      />
+      <input
+        v-model="lastName"
+        placeholder="Last name"
+        class="border rounded-md p-3 text-lg"
+      />
+      <button class="bg-blue-600 text-white py-3 rounded-md" type="submit">
+        Continue
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import api from '../api/ApiService';
+import { useSessionStore } from '../stores/session';
+
+const firstName = ref('');
+const lastName = ref('');
+const router = useRouter();
+const session = useSessionStore();
+
+const fetchProfile = async () => {
+  const { data } = await api.getProfile(session.token as string);
+  session.user = data;
+};
+
+const submit = async () => {
+  await api.completeProfile(
+    session.token as string,
+    firstName.value,
+    lastName.value
+  );
+  await fetchProfile();
+  router.push('/home');
+};
+</script>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{vue,ts}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});


### PR DESCRIPTION
## Summary
- configure Tailwind CSS with PostCSS and default config
- render the entire app in a centered fixed-size mobile frame
- implement login, code verification, registration and home views with Tailwind classes
- add index.html for Vite entry
- document the mobile frame setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b214d5ae48326b721abc640f67b88