### PR TITLE
Add env-based API config

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.sans-reserve.com

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ npm run dev
 
 The UI is built with Tailwind CSS and always renders inside a fixed mobile frame for consistent layout across devices.
 
+## Environment Variables
+
+Create a `.env.local` file in the project root and define `VITE_API_BASE_URL`:
+
+```bash
+VITE_API_BASE_URL=https://api.sans-reserve.com
+```
+
+If this variable is not set, the application falls back to `https://api.sans-reserve.com`.
+

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,1 +1,1 @@
-export const API_BASE_URL = 'https://api.sans-reserve.com';
+export const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL || 'https://api.sans-reserve.com';


### PR DESCRIPTION
## Summary
- allow overriding API base URL through environment variable
- document VITE_API_BASE_URL setup

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b30e4926083269abff10833133411