### PR TITLE
Add session refresh action

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,12 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
 import { createPinia } from 'pinia';
+import { useSessionStore } from './stores/session';
 import './assets/main.css';
 
-createApp(App)
-  .use(createPinia())
-  .use(router)
-  .mount('#app');
+const app = createApp(App);
+const pinia = createPinia();
+const session = useSessionStore(pinia);
+session.refresh();
+
+app.use(pinia).use(router).mount('#app');

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -43,5 +43,12 @@ export const useSessionStore = defineStore('session', {
       if (!this.expiry) return true;
       return Date.now() > this.expiry;
     },
+    refresh(days = 7) {
+      if (this.token && !this.isExpired()) {
+        const newExpiry = Date.now() + days * 24 * 60 * 60 * 1000;
+        this.expiry = newExpiry;
+        localStorage.setItem(EXPIRY_KEY, newExpiry.toString());
+      }
+    },
   },
 });


### PR DESCRIPTION
## Summary
- extend Pinia session store with a `refresh()` action
- call `refresh()` during app startup

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b30ea9d988326bb8356e5886a0a65