### PR TITLE
Improve error handling for API requests

### DIFF
--- a/src/api/ApiService.ts
+++ b/src/api/ApiService.ts
@@ -1,29 +1,47 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { API_BASE_URL } from '../config/api';
 
 class ApiService {
   private client = axios.create({ baseURL: API_BASE_URL });
 
-  public async sendPhoneNumber(phone: string) {
-    return this.client.post('/auth/login', { phone });
+  private handleError(error: unknown) {
+    console.error('API Error:', error);
+    throw error;
   }
 
-  public async verifyCode(phone: string, code: string) {
-    return this.client.post('/auth/verify', { phone, code });
+  private async request<T>(promise: Promise<AxiosResponse<T>>): Promise<AxiosResponse<T>> {
+    try {
+      return await promise;
+    } catch (error) {
+      this.handleError(error);
+      throw error; // rethrow so callers can handle it
+    }
   }
 
-  public async completeProfile(token: string, firstName: string, lastName: string) {
-    return this.client.post(
-      '/auth/register',
-      { firstName, lastName },
-      { headers: { Authorization: `Bearer ${token}` } }
+  public sendPhoneNumber(phone: string) {
+    return this.request(this.client.post('/auth/login', { phone }));
+  }
+
+  public verifyCode(phone: string, code: string) {
+    return this.request(this.client.post('/auth/verify', { phone, code }));
+  }
+
+  public completeProfile(token: string, firstName: string, lastName: string) {
+    return this.request(
+      this.client.post(
+        '/auth/register',
+        { firstName, lastName },
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
     );
   }
 
-  public async getProfile(token: string) {
-    return this.client.get('/user/profile', {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+  public getProfile(token: string) {
+    return this.request(
+      this.client.get('/user/profile', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    );
   }
 }
 

--- a/src/views/EnterCode.vue
+++ b/src/views/EnterCode.vue
@@ -11,6 +11,7 @@
         Verify
       </button>
     </form>
+    <p v-if="error" class="text-red-600 mt-2">{{ error }}</p>
   </div>
 </template>
 
@@ -25,21 +26,31 @@ const router = useRouter();
 const session = useSessionStore();
 
 const code = ref('');
+const error = ref<string | null>(null);
 const phone = route.query.phone as string;
 
 const fetchProfile = async () => {
-  const { data } = await api.getProfile(session.token as string);
-  session.user = data;
+  try {
+    const { data } = await api.getProfile(session.token as string);
+    session.user = data;
+  } catch (e) {
+    error.value = 'Failed to load profile';
+  }
 };
 
 const submit = async () => {
-  const { data } = await api.verifyCode(phone, code.value);
-  session.saveToken(data.token);
-  if (data.isNew) {
-    router.push('/register');
-  } else {
-    await fetchProfile();
-    router.push('/home');
+  error.value = null;
+  try {
+    const { data } = await api.verifyCode(phone, code.value);
+    session.saveToken(data.token);
+    if (data.isNew) {
+      router.push('/register');
+    } else {
+      await fetchProfile();
+      router.push('/home');
+    }
+  } catch (e) {
+    error.value = 'Verification failed';
   }
 };
 </script>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -12,6 +12,7 @@
         Send Code
       </button>
     </form>
+    <p v-if="error" class="text-red-600 mt-2">{{ error }}</p>
   </div>
 </template>
 
@@ -21,10 +22,16 @@ import api from '../api/ApiService';
 import { useRouter } from 'vue-router';
 
 const phone = ref('');
+const error = ref<string | null>(null);
 const router = useRouter();
 
 const submit = async () => {
-  await api.sendPhoneNumber(phone.value);
-  router.push({ path: '/enter-code', query: { phone: phone.value } });
+  error.value = null;
+  try {
+    await api.sendPhoneNumber(phone.value);
+    router.push({ path: '/enter-code', query: { phone: phone.value } });
+  } catch (e) {
+    error.value = 'Failed to send code';
+  }
 };
 </script>

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -16,6 +16,7 @@
         Continue
       </button>
     </form>
+    <p v-if="error" class="text-red-600 mt-2">{{ error }}</p>
   </div>
 </template>
 
@@ -27,21 +28,31 @@ import { useSessionStore } from '../stores/session';
 
 const firstName = ref('');
 const lastName = ref('');
+const error = ref<string | null>(null);
 const router = useRouter();
 const session = useSessionStore();
 
 const fetchProfile = async () => {
-  const { data } = await api.getProfile(session.token as string);
-  session.user = data;
+  try {
+    const { data } = await api.getProfile(session.token as string);
+    session.user = data;
+  } catch (e) {
+    error.value = 'Failed to load profile';
+  }
 };
 
 const submit = async () => {
-  await api.completeProfile(
-    session.token as string,
-    firstName.value,
-    lastName.value
-  );
-  await fetchProfile();
-  router.push('/home');
+  error.value = null;
+  try {
+    await api.completeProfile(
+      session.token as string,
+      firstName.value,
+      lastName.value
+    );
+    await fetchProfile();
+    router.push('/home');
+  } catch (e) {
+    error.value = 'Profile update failed';
+  }
 };
 </script>


### PR DESCRIPTION
## Summary
- handle API errors centrally in `ApiService`
- show failures in Login, EnterCode and Register views

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b30ef3e1083268029d847879e766f