### PR TITLE
Implement session expiry refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,16 @@ import App from './App.vue';
 import router from './router';
 import { createPinia } from 'pinia';
 import { useLocaleStore } from './stores/locale';
+import { useSessionStore } from './stores/session';
 import './assets/main.css';
 
 const app = createApp(App);
 const pinia = createPinia();
 
 app.use(pinia).use(router);
+
+const session = useSessionStore();
+session.refreshExpiry();
 
 // Keep document direction in sync with the current locale
 const locale = useLocaleStore();

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -50,5 +50,12 @@ export const useSessionStore = defineStore('session', {
         localStorage.setItem(EXPIRY_KEY, newExpiry.toString());
       }
     },
+    refreshExpiry() {
+      if (this.token && !this.isExpired()) {
+        const newExpiry = Date.now() + 7 * 24 * 60 * 60 * 1000;
+        this.expiry = newExpiry;
+        localStorage.setItem(EXPIRY_KEY, newExpiry.toString());
+      }
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add `refreshExpiry()` action in session store
- refresh session expiry when the app starts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b35b52ed883269dd220576a7351e7