### PR TITLE
Implement i18n and loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.1",
       "dependencies": {
         "@capacitor/core": "^7.4.0",
+        "naive-ui": "^2.42.0",
         "npm-check-updates": "^18.0.1",
         "pinia": "^3.0.3",
         "vue": "^3.5.17",
+        "vue-i18n": "^11.1.8",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -105,6 +107,30 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/@css-render/plugin-bem": {
+      "version": "0.15.14",
+      "resolved": "https://registry.npmjs.org/@css-render/plugin-bem/-/plugin-bem-0.15.14.tgz",
+      "integrity": "sha512-QK513CJ7yEQxm/P3EwsI+d+ha8kSOcjGvD6SevM41neEMxdULE+18iuQK6tEChAWMOQNQPLG/Rw3Khb69r5neg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "css-render": "~0.15.14"
+      }
+    },
+    "node_modules/@css-render/vue3-ssr": {
+      "version": "0.15.14",
+      "resolved": "https://registry.npmjs.org/@css-render/vue3-ssr/-/vue3-ssr-0.15.14.tgz",
+      "integrity": "sha512-//8027GSbxE9n3QlD73xFY6z4ZbHbvrOVB7AO6hsmrEzGbg+h2A09HboUyDgu+xsmj7JnvJD39Irt+2D0+iV8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.11"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -531,6 +557,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.1.8.tgz",
+      "integrity": "sha512-BAdeGNapg9HL55k2QJPisa6y3FGnIqVK3Yjub2iUEuS88Jf4AY5hD8wm42FW6lEda921S8scWuKkmb6GUWKlqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "11.1.8",
+        "@intlify/shared": "11.1.8"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.8.tgz",
+      "integrity": "sha512-4YCeg7L2kt89t6nKSSFACAnTBnBMXu0IfG49+pac2VWkWJ7h9AQcsOD3iCptMGuoEj7hcaoNA4F+K/qA7bJxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.1.8",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.8.tgz",
+      "integrity": "sha512-Fpo7YgkT8jwOuSOwOQXrMwqdljEqdfSYdIFkGkpRi80xVCAXpc6MTzuP2pkuQVDXU9MPNC05TWrETzCr+zjuRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -581,6 +651,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
@@ -1152,6 +1228,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.0.tgz",
@@ -1299,6 +1396,12 @@
       "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
       "license": "MIT"
     },
+    "node_modules/async-validator": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
+      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1425,11 +1528,46 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/css-render": {
+      "version": "0.15.14",
+      "resolved": "https://registry.npmjs.org/css-render/-/css-render-0.15.14.tgz",
+      "integrity": "sha512-9nF4PdUle+5ta4W5SyZdLCCmFd37uVimSjg1evcTqKJCyvCEEj12WKzOSBNak6r4im4J4iYXKH1OWpUV5LBYFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "~0.8.0",
+        "csstype": "~3.0.5"
+      }
+    },
+    "node_modules/css-render/node_modules/csstype": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -1531,6 +1669,12 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/evtd": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/evtd/-/evtd-0.2.4.tgz",
+      "integrity": "sha512-qaeGN5bx63s/AXgQo8gj6fBkxge+OoLddLniox5qtLAEY5HSnuSlISXVPxnSae1dWblvTh4/HoMIB+mbMsvZzw==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -1581,6 +1725,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/hookable": {
       "version": "5.5.3",
@@ -1849,6 +2002,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -1901,6 +2066,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/naive-ui": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/naive-ui/-/naive-ui-2.42.0.tgz",
+      "integrity": "sha512-c7cXR2YgOjgtBadXHwiWL4Y0tpGLAI5W5QzzHksOi22iuHXoSGMAzdkVTGVPE/PM0MSGQ/JtUIzCx2Y0hU0vTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@css-render/plugin-bem": "^0.15.14",
+        "@css-render/vue3-ssr": "^0.15.14",
+        "@types/katex": "^0.16.2",
+        "@types/lodash": "^4.14.198",
+        "@types/lodash-es": "^4.17.9",
+        "async-validator": "^4.2.5",
+        "css-render": "^0.15.14",
+        "csstype": "^3.1.3",
+        "date-fns": "^3.6.0",
+        "date-fns-tz": "^3.1.3",
+        "evtd": "^0.2.4",
+        "highlight.js": "^11.8.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "seemly": "^0.3.8",
+        "treemate": "^0.3.11",
+        "vdirs": "^0.1.8",
+        "vooks": "^0.2.12",
+        "vueuc": "^0.4.63"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -2088,6 +2283,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/seemly": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/seemly/-/seemly-0.3.10.tgz",
+      "integrity": "sha512-2+SMxtG1PcsL0uyhkumlOU6Qo9TAQ/WyH7tthnPIOQB05/12jz9naq6GZ6iZ6ApVsO3rr2gsnTf3++OV63kE1Q==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2170,6 +2371,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/treemate": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/treemate/-/treemate-0.3.11.tgz",
+      "integrity": "sha512-M8RGFoKtZ8dF+iwJfAJTOH/SM4KluKOKRJpjCMhI8bG3qB74zrFoArKZ62ll0Fr3mqkMJiQOmWYkdYgDeITYQg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2219,6 +2426,18 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vdirs": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/vdirs/-/vdirs-0.1.8.tgz",
+      "integrity": "sha512-H9V1zGRLQZg9b+GdMk8MXDN2Lva0zx72MPahDKc30v+DtwKjfyOSXWRIX4t2mhDubM1H09gPhWeth/BJWPHGUw==",
+      "license": "MIT",
+      "dependencies": {
+        "evtd": "^0.2.2"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.11"
       }
     },
     "node_modules/vite": {
@@ -2296,6 +2515,18 @@
         }
       }
     },
+    "node_modules/vooks": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/vooks/-/vooks-0.2.12.tgz",
+      "integrity": "sha512-iox0I3RZzxtKlcgYaStQYKEzWWGAduMmq+jS7OrNdQo1FgGfPMubGL3uGHOU9n97NIvfFDBGnpSvkWyb/NSn/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "evtd": "^0.2.2"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
@@ -2317,6 +2548,26 @@
         }
       }
     },
+    "node_modules/vue-i18n": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.1.8.tgz",
+      "integrity": "sha512-2JHUseyUrjlguX2N72SAKZ4UBDZ2lo22gL2SMQ6jWJh98RB59nUIQNPE9xKKkSgK5cflj9un8SAwfjYg/PHMxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.1.8",
+        "@intlify/shared": "11.1.8",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
@@ -2330,6 +2581,24 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vueuc": {
+      "version": "0.4.64",
+      "resolved": "https://registry.npmjs.org/vueuc/-/vueuc-0.4.64.tgz",
+      "integrity": "sha512-wlJQj7fIwKK2pOEoOq4Aro8JdPOGpX8aWQhV8YkTW9OgWD2uj2O8ANzvSsIGjx7LTOc7QbS7sXdxHi6XvRnHPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@css-render/vue3-ssr": "^0.15.10",
+        "@juggle/resize-observer": "^3.3.1",
+        "css-render": "^0.15.10",
+        "evtd": "^0.2.4",
+        "seemly": "^0.3.6",
+        "vdirs": "^0.1.4",
+        "vooks": "^0.2.4"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.11"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   },
   "dependencies": {
     "@capacitor/core": "^7.4.0",
+    "naive-ui": "^2.42.0",
     "npm-check-updates": "^18.0.1",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",
+    "vue-i18n": "^11.1.8",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,53 @@
+import { createI18n } from 'vue-i18n';
+
+const messages = {
+  fa: {
+    login: 'ورود',
+    mobile_placeholder: 'شماره موبایل',
+    send_code: 'ارسال کد',
+    enter_code: 'ورود کد',
+    sms_code_placeholder: 'کد پیامک',
+    verify: 'تایید',
+    complete_profile: 'تکمیل پروفایل',
+    first_name: 'نام',
+    last_name: 'نام خانوادگی',
+    continue: 'ادامه',
+    welcome: 'خوش آمدید',
+    logout: 'خروج',
+    send_code_failed: 'ارسال کد انجام نشد',
+    verification_failed: 'تایید انجام نشد',
+    profile_update_failed: 'به‌روزرسانی پروفایل انجام نشد',
+    load_profile_failed: 'خطا در دریافت پروفایل',
+    connection_error: 'اتصال اینترنت برقرار نیست',
+    retry: 'تلاش دوباره',
+    loading: 'در حال بررسی اتصال...'
+  },
+  en: {
+    login: 'Login',
+    mobile_placeholder: 'Mobile number',
+    send_code: 'Send Code',
+    enter_code: 'Enter Code',
+    sms_code_placeholder: 'SMS Code',
+    verify: 'Verify',
+    complete_profile: 'Complete Profile',
+    first_name: 'First name',
+    last_name: 'Last name',
+    continue: 'Continue',
+    welcome: 'Welcome',
+    logout: 'Logout',
+    send_code_failed: 'Failed to send code',
+    verification_failed: 'Verification failed',
+    profile_update_failed: 'Profile update failed',
+    load_profile_failed: 'Failed to load profile',
+    connection_error: 'No internet connection',
+    retry: 'Retry',
+    loading: 'Checking connection...'
+  }
+};
+
+export default createI18n({
+  legacy: false,
+  locale: 'fa',
+  fallbackLocale: 'en',
+  messages
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,13 @@ import router from './router';
 import { createPinia } from 'pinia';
 import { useLocaleStore } from './stores/locale';
 import { useSessionStore } from './stores/session';
+import i18n from './i18n';
 import './assets/main.css';
 
 const app = createApp(App);
 const pinia = createPinia();
 
-app.use(pinia).use(router);
+app.use(pinia).use(router).use(i18n);
 
 const session = useSessionStore();
 session.refreshExpiry();
@@ -27,6 +28,7 @@ watch(
   () => locale.locale,
   (lang) => {
     document.documentElement.lang = lang;
+    i18n.global.locale.value = lang;
   },
   { immediate: true }
 );

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,10 +3,11 @@ import Login from '../views/Login.vue';
 import EnterCode from '../views/EnterCode.vue';
 import Register from '../views/Register.vue';
 import Home from '../views/Home.vue';
+import Loader from '../views/Loader.vue';
 import { useSessionStore } from '../stores/session';
 
 const routes = [
-  { path: '/', redirect: '/login' },
+  { path: '/', component: Loader },
   { path: '/login', component: Login },
   { path: '/enter-code', component: EnterCode },
   { path: '/register', component: Register },
@@ -20,7 +21,7 @@ const router = createRouter({
 
 router.beforeEach((to, _from, next) => {
   const session = useSessionStore();
-  if (['/login', '/enter-code', '/register'].includes(to.path)) {
+  if (['/login', '/enter-code', '/register', '/'].includes(to.path)) {
     next();
   } else {
     if (!session.token || session.isExpired()) {

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -10,8 +10,8 @@ interface LocaleState {
 
 export const useLocaleStore = defineStore('locale', {
   state: (): LocaleState => ({
-    locale: navigator.language || 'en',
-    dir: 'ltr',
+    locale: 'fa',
+    dir: 'rtl',
   }),
   actions: {
     setLocale(locale: string) {

--- a/src/views/EnterCode.vue
+++ b/src/views/EnterCode.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="p-4 flex flex-col h-full">
-    <h1 class="text-xl font-semibold text-center mb-4">Enter Code</h1>
+    <h1 class="text-xl font-semibold text-center mb-4">{{ t('enter_code') }}</h1>
     <form class="flex flex-col gap-4" @submit.prevent="submit">
-      <input
-        v-model="code"
-        placeholder="SMS Code"
-        class="border rounded-md p-3 text-lg"
+      <n-input-otp
+        v-model:value="code"
+        :length="6"
+        placeholder="{{ t('sms_code_placeholder') }}"
       />
       <button class="bg-blue-600 text-white py-3 rounded-md" type="submit">
-        Verify
+        {{ t('verify') }}
       </button>
     </form>
     <p v-if="error" class="text-red-600 mt-2">{{ error }}</p>
@@ -20,6 +20,8 @@ import { ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '../api/ApiService';
 import { useSessionStore } from '../stores/session';
+import { useI18n } from 'vue-i18n';
+import { NInputOtp } from 'naive-ui';
 
 const route = useRoute();
 const router = useRouter();
@@ -27,6 +29,7 @@ const session = useSessionStore();
 
 const code = ref('');
 const error = ref<string | null>(null);
+const { t } = useI18n();
 const phone = route.query.phone as string;
 
 const fetchProfile = async () => {
@@ -34,7 +37,7 @@ const fetchProfile = async () => {
     const { data } = await api.getProfile(session.token as string);
     session.user = data;
   } catch (e) {
-    error.value = 'Failed to load profile';
+    error.value = t('load_profile_failed');
   }
 };
 
@@ -50,7 +53,7 @@ const submit = async () => {
       router.push('/home');
     }
   } catch (e) {
-    error.value = 'Verification failed';
+    error.value = t('verification_failed');
   }
 };
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="p-4 flex flex-col h-full">
     <h1 class="text-xl font-semibold text-center mb-4">
-      Welcome {{ session.user?.firstName }}
+      {{ t('welcome') }} {{ session.user?.firstName }}
     </h1>
     <button class="bg-red-600 text-white py-3 rounded-md" @click="logout">
-      Logout
+      {{ t('logout') }}
     </button>
   </div>
 </template>
@@ -12,9 +12,11 @@
 <script setup lang="ts">
 import { useSessionStore } from '../stores/session';
 import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 const session = useSessionStore();
 const router = useRouter();
+const { t } = useI18n();
 
 const logout = () => {
   session.clear();

--- a/src/views/Loader.vue
+++ b/src/views/Loader.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="flex flex-col items-center justify-center h-full p-4">
+    <div v-if="checking" class="text-center">
+      <p>{{ t('loading') }}</p>
+    </div>
+    <div v-else-if="offline" class="text-center">
+      <p class="mb-4 text-red-600">{{ t('connection_error') }}</p>
+      <button class="bg-blue-600 text-white py-2 px-4 rounded-md" @click="check">
+        {{ t('retry') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useSessionStore } from '../stores/session';
+import { useI18n } from 'vue-i18n';
+
+const router = useRouter();
+const session = useSessionStore();
+const { t } = useI18n();
+
+const checking = ref(true);
+const offline = ref(false);
+
+const proceed = () => {
+  if (session.token && !session.isExpired()) {
+    router.replace('/home');
+  } else {
+    router.replace('/login');
+  }
+};
+
+const check = () => {
+  checking.value = true;
+  offline.value = false;
+  if (navigator.onLine) {
+    proceed();
+  } else {
+    offline.value = true;
+  }
+  checking.value = false;
+};
+
+onMounted(() => {
+  check();
+});
+</script>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,15 +1,18 @@
 <template>
   <div class="p-4 flex flex-col h-full">
-    <h1 class="text-xl font-semibold text-center mb-4">Login</h1>
+    <h1 class="text-xl font-semibold text-center mb-4">{{ t('login') }}</h1>
     <form class="flex flex-col gap-4" @submit.prevent="submit">
-      <input
-        v-model="phone"
-        type="tel"
-        placeholder="Mobile number"
-        class="border rounded-md p-3 text-lg"
-      />
+      <div class="flex items-center border rounded-md p-3 text-lg">
+        <span class="mr-2 select-none">+98</span>
+        <input
+          v-model="phone"
+          type="tel"
+          placeholder="{{ t('mobile_placeholder') }}"
+          class="flex-1 outline-none"
+        />
+      </div>
       <button class="bg-blue-600 text-white py-3 rounded-md" type="submit">
-        Send Code
+        {{ t('send_code') }}
       </button>
     </form>
     <p v-if="error" class="text-red-600 mt-2">{{ error }}</p>
@@ -20,18 +23,21 @@
 import { ref } from 'vue';
 import api from '../api/ApiService';
 import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 const phone = ref('');
 const error = ref<string | null>(null);
 const router = useRouter();
+const { t } = useI18n();
 
 const submit = async () => {
   error.value = null;
   try {
-    await api.sendPhoneNumber(phone.value);
-    router.push({ path: '/enter-code', query: { phone: phone.value } });
+    const normalized = phone.value.replace(/^0/, '');
+    await api.sendPhoneNumber(normalized);
+    router.push({ path: '/enter-code', query: { phone: normalized } });
   } catch (e) {
-    error.value = 'Failed to send code';
+    error.value = t('send_code_failed');
   }
 };
 </script>

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="p-4 flex flex-col h-full">
-    <h1 class="text-xl font-semibold text-center mb-4">Complete Profile</h1>
+    <h1 class="text-xl font-semibold text-center mb-4">{{ t('complete_profile') }}</h1>
     <form class="flex flex-col gap-4" @submit.prevent="submit">
       <input
         v-model="firstName"
-        placeholder="First name"
+        :placeholder="t('first_name')"
         class="border rounded-md p-3 text-lg"
       />
       <input
         v-model="lastName"
-        placeholder="Last name"
+        :placeholder="t('last_name')"
         class="border rounded-md p-3 text-lg"
       />
       <button class="bg-blue-600 text-white py-3 rounded-md" type="submit">
-        Continue
+        {{ t('continue') }}
       </button>
     </form>
     <p v-if="error" class="text-red-600 mt-2">{{ error }}</p>
@@ -25,19 +25,21 @@ import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import api from '../api/ApiService';
 import { useSessionStore } from '../stores/session';
+import { useI18n } from 'vue-i18n';
 
 const firstName = ref('');
 const lastName = ref('');
 const error = ref<string | null>(null);
 const router = useRouter();
 const session = useSessionStore();
+const { t } = useI18n();
 
 const fetchProfile = async () => {
   try {
     const { data } = await api.getProfile(session.token as string);
     session.user = data;
   } catch (e) {
-    error.value = 'Failed to load profile';
+    error.value = t('load_profile_failed');
   }
 };
 
@@ -52,7 +54,7 @@ const submit = async () => {
     await fetchProfile();
     router.push('/home');
   } catch (e) {
-    error.value = 'Profile update failed';
+    error.value = t('profile_update_failed');
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- add Vue i18n setup with Persian defaults
- add loader page for connectivity check
- integrate i18n into views and update locale store
- use Naive UI `n-input-otp` for code entry
- show +98 prefix on login phone field

## Testing
- `npm run build` *(fails: PostCSS plugin for Tailwind CSS missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865bf20f3ac83269972422e98bbfd2b