### PR TITLE
Fix Tailwind PostCSS configuration

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('@tailwindcss/postcss'),
+    require('autoprefixer'),
+  ],
 };


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` plugin for PostCSS

## Testing
- `npm run build` *(fails: Cannot apply unknown utility class `m-0`)*

------
https://chatgpt.com/codex/tasks/task_e_686689935b4883269aaf8ec0bfc9d792